### PR TITLE
refactor: 适配0.77，rn侧组件继承ViewProps

### DIFF
--- a/src/BarChartsComponent.ts
+++ b/src/BarChartsComponent.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -273,7 +273,7 @@ export interface BarData {
 
     config?:configType;
 }
-export interface BarChartProps extends BarLineChartBase{
+export interface BarChartProps extends ViewProps, BarLineChartBase{
     drawValueAboveBar?: boolean;
     drawBarShadow?: boolean;
     highlightFullBarEnabled?: boolean;

--- a/src/BubbleChartNativeCompnents.ts
+++ b/src/BubbleChartNativeCompnents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -267,7 +267,7 @@ export interface BubbleDataset extends Dataset {
 export interface BubbleData {
     dataSets?: BubbleDataset[] ;
 }
-export interface BubbleChartProps extends BarLineChartBase{
+export interface BubbleChartProps extends ViewProps, BarLineChartBase{
     data: BubbleData;
   }
 

--- a/src/CandleNativeComponents.ts
+++ b/src/CandleNativeComponents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -287,7 +287,7 @@ export interface CandleStickDataset extends Dataset {
 export interface CandleStickData {
     dataSets?: CandleStickDataset[] ;
 }
-export interface CandleStickChartProps extends BarLineChartBase{
+export interface CandleStickChartProps extends ViewProps, BarLineChartBase{
     data: CandleStickData;
   }
 

--- a/src/CombinedChartNativeComponents.ts
+++ b/src/CombinedChartNativeComponents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
 } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -440,7 +440,7 @@ type DrawOrderType = "BAR" | "BUBBLE" | "LINE" | "CANDLE" | "SCATTER"
 
 type DrawOrderTypeArr = DrawOrderType[]
 
-export interface CombinedChartProps extends BarLineChartBase {
+export interface CombinedChartProps extends ViewProps, BarLineChartBase {
     drawOrder?: WithDefault<DrawOrderTypeArr, 'BAR'>;
     drawValueAboveBar?: boolean ;
     highlightFullBarEnabled?: boolean ;

--- a/src/HorBarChartNativeComponents.ts
+++ b/src/HorBarChartNativeComponents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -273,7 +273,7 @@ export interface BarData {
 
     config?:configType;
 }
-export interface HorizontalBarChartProps extends BarLineChartBase{
+export interface HorizontalBarChartProps extends ViewProps, BarLineChartBase{
     drawValueAboveBar?: boolean;
     drawBarShadow?: boolean;
     highlightFullBarEnabled?: boolean;

--- a/src/LineChartNativeComponents.ts
+++ b/src/LineChartNativeComponents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -309,7 +309,7 @@ export interface LineDataset extends Dataset {
 export interface LineData {
     dataSets?: LineDataset[] ;
 }
-export interface LineChartProps extends BarLineChartBase{
+export interface LineChartProps extends ViewProps,BarLineChartBase{
     data: LineData;
   }
 

--- a/src/PieChartNativeComponents.ts
+++ b/src/PieChartNativeComponents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -202,7 +202,7 @@ interface styledCenterTextType {
     size?: Float ;
     fontFamily?: FontFamily ;
 }
-export interface PieChartProps extends PieRadarChartBase{
+export interface PieChartProps extends ViewProps, PieRadarChartBase{
     drawEntryLabels?: boolean ;
     usePercentValues?: boolean ;
 

--- a/src/RadarChartNativeComponents.ts
+++ b/src/RadarChartNativeComponents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -232,7 +232,7 @@ export interface yAxis extends Axis {
 
     zeroLine?:zeroLineType
 }
-export interface RadarChartProps extends PieRadarChartBase{
+export interface RadarChartProps extends ViewProps, PieRadarChartBase{
     yAxis?: yAxis ;
 
     drawWeb?: boolean ;

--- a/src/ScatterChartNativeComponents.ts
+++ b/src/ScatterChartNativeComponents.ts
@@ -1,5 +1,5 @@
 import {
-    HostComponent,
+    HostComponent,ViewProps
   } from "react-native";
 import { Float, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -293,7 +293,7 @@ export interface ScatterDataset extends Dataset {
 export interface ScatterData {
     dataSets: ScatterDataset[];
 }
-export interface ScatterChartProps extends BarLineChartBase{
+export interface ScatterChartProps extends ViewProps, BarLineChartBase{
     data: ScatterData;
   }
 


### PR DESCRIPTION
# Summary

- 适配0.77，rn侧组件继承ViewProps。

## Test Plan

<img width="421" height="889" alt="image" src="https://github.com/user-attachments/assets/33ff87d0-d7e8-474a-82b7-afbe3eea175e" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

